### PR TITLE
Update README to mention compatibility with Gemma M0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 <a href="http://www.adafruit.com/products/1981"><img src="assets/image.jpg?raw=true" width="500px"><br/>
 Click here to purchase one from the Adafruit shop</a>
 
-Your wearable can now keep you from getting sunburnt, with the Flora digital UV index sensor. We took our popular SI1145 UV index sensor and cut out everything you don't need for using with a Flora. It's small, round, and connects to the I2C bus pads. Flora can even use our library code to get calibrated light level and UV index data from the sensor.
+Your wearable can now keep you from getting sunburnt, with the Flora digital UV index sensor. We took our popular SI1145 UV index sensor and cut out everything you don't need for using with our wearable platforms: Flora and Gemma M0. It's small, round, and connects to the I2C bus pads. Flora and Gemma M0 can even use our library code to get calibrated light level and UV index data from the sensor.
 
-Please note: this sensor can be used by Flora but is too complex for Gemma Classic (ATtiny85)!
+Please note: this sensor can be used by <a href="https://www.adafruit.com/product/659">Flora</a> and <a href="https://www.adafruit.com/product/3501">Gemma M0</a> but is too complex for <a href="https://www.adafruit.com/product/1222">Gemma v2 (ATtiny85)</a>!
 
 PCB files for the Adafruit Flora Si1145 Light Sensor. The format is EagleCAD schematic and board layout
 - https://www.adafruit.com/product/1981


### PR DESCRIPTION
# What does this PR do?
Added mention of sensor being compatible with Gemma M0.

# Why is this PR needed?
This will keep new readers/makers/customers up to date about what microcontroller one can use with this sensor. <a href="https://www.adafruit.com/product/3501">Gemma M0's technical details mention that it is supports I2C</a>, so this information is available in one source, but not in all places. Making this change will be a step towards having this information available in more places 🎈😊 